### PR TITLE
Integrate LinksParser into crawler

### DIFF
--- a/seofrog/core/crawler.py
+++ b/seofrog/core/crawler.py
@@ -34,6 +34,7 @@ from seofrog.parsers.meta_parser import MetaParser
 from seofrog.parsers.technical_parser import TechnicalParser
 from seofrog.parsers.social_parser import SocialParser
 from seofrog.parsers.schema_parser import SchemaParser
+from seofrog.parsers.links_parser import LinksParser
 
 from seofrog.exporters.csv_exporter import CSVExporter
 
@@ -499,6 +500,7 @@ class SEOFrog:
         self.technical_parser = TechnicalParser()
         self.social_parser = SocialParser()
         self.schema_parser = SchemaParser()
+        self.links_parser = LinksParser()
         
         self.exporter = CSVExporter(config.output_dir)
         
@@ -635,12 +637,14 @@ class SEOFrog:
             technical_data = self.technical_parser.parse(soup, url)
             social_data = self.social_parser.parse(soup, url)
             schema_data = self.schema_parser.parse(soup, url)
-            
+            links_data = self.links_parser.parse(soup, url)
+
             # Merge todos os dados
             data.update(meta_data)
             data.update(technical_data)
             data.update(social_data)
             data.update(schema_data)
+            data.update(links_data)
             
             # 🚀 ADICIONA DADOS DETALHADOS DE REDIRECT
             if redirect_chain:
@@ -921,7 +925,7 @@ class SEOFrog:
         
         self.progress_logger.log_final_stats(len(self.results), success_count, error_count)
         self.logger.info(f"✅ SEOFrog crawl finalizado! {len(self.results)} URLs processadas em {elapsed:.1f}s")
-        
+        self.links_parser.close()
         return self.results
     
     def export_results(self, format: str = 'xlsx', filename: str = None) -> str:

--- a/tests/test_links_parser_integration.py
+++ b/tests/test_links_parser_integration.py
@@ -1,0 +1,56 @@
+import datetime
+import requests
+
+from seofrog.core.crawler import SEOFrog, URLManager
+from seofrog.core.config import CrawlConfig
+
+
+class DummyHTTPEngine:
+    def __init__(self, response, redirect_chain=None):
+        self.response = response
+        self.redirect_chain = redirect_chain or []
+
+    def fetch_url(self, url):
+        return self.response, self.redirect_chain, {}
+
+
+def make_response(url, html, status_code=200, final_url=None):
+    resp = requests.Response()
+    resp.status_code = status_code
+    resp._content = html.encode("utf-8")
+    resp.headers["content-type"] = "text/html"
+    resp.url = final_url or url
+    resp.elapsed = datetime.timedelta(seconds=0.1)
+    return resp
+
+
+def setup_seofrog(response, redirect_chain=None):
+    config = CrawlConfig(max_urls=10, max_depth=1, respect_robots=False)
+    crawler = SEOFrog(config)
+    crawler.url_manager = URLManager("example.com")
+    crawler.http_engine = DummyHTTPEngine(response, redirect_chain)
+    return crawler
+
+
+def test_internal_links_parsed():
+    html = "<html><body><a href='/about'>About</a><a href='http://ext.com'>Ext</a></body></html>"
+    resp = make_response("http://example.com", html)
+    crawler = setup_seofrog(resp)
+
+    result = crawler.crawl_url("http://example.com", 0)
+    assert "internal_links_details" in result
+    assert len(result["internal_links_details"]) == 1
+    assert result["has_redirect"] is False
+
+
+def test_redirect_info_populated():
+    html = "<html><body><a href='/next'>Next</a></body></html>"
+    resp = make_response("http://example.com", html, final_url="http://example.com/home")
+    redirect_chain = [{"url": "http://example.com", "status_code": 301, "location": "/home"}]
+    crawler = setup_seofrog(resp, redirect_chain)
+
+    result = crawler.crawl_url("http://example.com", 0)
+    assert result["has_redirect"] is True
+    assert result["redirect_chain_length"] == 1
+    assert result["redirect_status_code"] == 301
+    assert result["internal_links_details"]


### PR DESCRIPTION
## Summary
- include LinksParser in crawler initialization
- parse links data while crawling
- close LinksParser resources when crawl ends
- add regression tests for internal link parsing and redirect info

## Testing
- `pip install requests beautifulsoup4 lxml pytest -q` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6869bc444e1c832a91195076eb737479