### PR TITLE
Implement SEOParser class

### DIFF
--- a/seofrog/parsers/seo_parser.py
+++ b/seofrog/parsers/seo_parser.py
@@ -1,91 +1,103 @@
 """
-PATCH 2: seofrog/parsers/seo_parser.py
-Corrige como os dados de redirects são passados para o DataFrame
+seofrog/parsers/seo_parser.py
+High level parser that aggregates all modular parsers.
 """
 
-# ✅ Encontre esta seção no seo_parser.py e substitua:
+from typing import Any, Dict, Union
+from bs4 import BeautifulSoup
 
-# ANTES (PROBLEMÁTICO):
-# data['internal_redirects_details'] = self.links_parser.internal_redirect_links
+from .meta_parser import MetaParser
+from .technical_parser import TechnicalParser
+from .social_parser import SocialParser
+from .schema_parser import SchemaParser
+from .links_parser import LinksParser
+from seofrog.utils.logger import get_logger
 
-# DEPOIS (CORRETO):
-def parse_url_data(self, soup: BeautifulSoup, url: str) -> Dict[str, Any]:
-    """
-    Parse completo de uma URL com todos os parsers modulares
-    ✅ CORRIGIDO: Dados de redirects específicos por URL
-    """
-    data = {'url': url}
-    
-    try:
-        # ... outros parsers ...
-        
-        # 7. LINKS PARSER (com correção)
+
+class SEOParser:
+    """Aggregate parser that runs all individual parsers for a page."""
+
+    def __init__(self) -> None:
+        self.logger = get_logger("SEOParser")
+        self.meta_parser = MetaParser()
+        self.technical_parser = TechnicalParser()
+        self.social_parser = SocialParser()
+        self.schema_parser = SchemaParser()
+        self.links_parser = LinksParser()
+
+    # ------------------------------------------------------------------
+    def parse_url_data(self, soup: BeautifulSoup, url: str) -> Dict[str, Any]:
+        """Parse a BeautifulSoup object and return SEO information."""
+        data: Dict[str, Any] = {"url": url}
+
         try:
-            word_count = data.get('word_count')
+            data.update(self.meta_parser.parse(soup, url))
+            data.update(self.technical_parser.parse(soup, url))
+            data.update(self.social_parser.parse(soup, url))
+            data.update(self.schema_parser.parse(soup, url))
+
+            word_count = data.get("word_count")
             links_data = self.links_parser.parse(soup, url, word_count)
             data.update(links_data)
             self.logger.debug(f"✅ LinksParser: {len(links_data)} campos")
 
-            # ✅ CORREÇÃO PRINCIPAL: Dados específicos desta URL
             redirects_for_this_url = self.links_parser.get_redirects_for_url(url)
-            
             if redirects_for_this_url:
-                # Converte estrutura normalizada para formato legado (compatibilidade)
                 legacy_format = []
                 for redirect in redirects_for_this_url:
-                    legacy_item = {
-                        'From': redirect.get('from_url', ''),
-                        'To (Original)': redirect.get('to_original', ''),
-                        'To (Final)': redirect.get('to_final', ''),
-                        'Anchor': redirect.get('anchor_text', ''),
-                        'Alt Text': redirect.get('alt_text', ''),
-                        'Follow': 'True' if redirect.get('follow', True) else 'False',
-                        'Target': redirect.get('target', ''),
-                        'Rel': redirect.get('rel', ''),
-                        'Código': redirect.get('status_code', ''),
-                        'Criticidade': redirect.get('criticidade', ''),
-                        'Sugestão': redirect.get('sugestao', ''),
-                        'Link Path': redirect.get('link_path', '')
-                    }
-                    legacy_format.append(legacy_item)
-                
-                data['internal_redirects_details'] = legacy_format
-                self.logger.debug(f"✅ {len(legacy_format)} redirects específicos para {url}")
+                    legacy_format.append(
+                        {
+                            "From": redirect.get("from_url", ""),
+                            "To (Original)": redirect.get("to_original", ""),
+                            "To (Final)": redirect.get("to_final", ""),
+                            "Anchor": redirect.get("anchor_text", ""),
+                            "Alt Text": redirect.get("alt_text", ""),
+                            "Follow": "True" if redirect.get("follow", True) else "False",
+                            "Target": redirect.get("target", ""),
+                            "Rel": redirect.get("rel", ""),
+                            "Código": redirect.get("status_code", ""),
+                            "Criticidade": redirect.get("criticidade", ""),
+                            "Sugestão": redirect.get("sugestao", ""),
+                            "Link Path": redirect.get("link_path", ""),
+                        }
+                    )
+                data["internal_redirects_details"] = legacy_format
+                self.logger.debug(
+                    f"✅ {len(legacy_format)} redirects específicos para {url}"
+                )
             else:
-                data['internal_redirects_details'] = []
-                
-            # ✅ NOVO: Estatísticas gerais de redirects
+                data["internal_redirects_details"] = []
+
             total_redirects = self.links_parser.get_total_redirects_count()
-            data['total_redirects_found'] = total_redirects
-            
-        except Exception as e:
-            self.logger.error(f"❌ LinksParser falhou: {e}")
-            data['links_parser_error'] = str(e)
-            data['internal_redirects_details'] = []  # ✅ Fallback seguro
-        
-        # ... resto do código ...
-        
-        # ✅ Log final com estatísticas
-        total_fields = len(data)
-        errors = len([k for k in data.keys() if k.endswith('_parser_error')])
-        redirects_count = len(data.get('internal_redirects_details', []))
-        
-        self.logger.info(f"🌟 Parsing completo: {total_fields} campos, {redirects_count} redirects")
-        if errors > 0:
-            self.logger.warning(f"⚠️ {errors} parsers com erro")
+            data["total_redirects_found"] = total_redirects
 
-        return data
+            total_fields = len(data)
+            errors = len([k for k in data.keys() if k.endswith("_parser_error")])
+            redirects_count = len(data.get("internal_redirects_details", []))
 
-    except Exception as e:
-        self.logger.error(f"❌ Erro crítico no parsing de {url}: {e}")
-        data['parse_error'] = str(e)
-        data['internal_redirects_details'] = []  # ✅ Fallback seguro
-        return data
+            self.logger.info(
+                f"🌟 Parsing completo: {total_fields} campos, {redirects_count} redirects"
+            )
+            if errors > 0:
+                self.logger.warning(f"⚠️ {errors} parsers com erro")
 
-# ✅ NOVO: Método para log final do crawl
-def finalize_parsing(self):
-    """
-    Finaliza parsing e exibe resumo dos redirects encontrados
-    """
-    if hasattr(self, 'links_parser') and self.links_parser:
-        self.links_parser.log_redirect_summary()
+            return data
+        except Exception as e:  # pragma: no cover - unexpected issues
+            self.logger.error(f"❌ Erro crítico no parsing de {url}: {e}")
+            data["parse_error"] = str(e)
+            data["internal_redirects_details"] = []
+            return data
+
+    # ------------------------------------------------------------------
+    def parse_page(self, url: str, response: Any) -> Dict[str, Any]:
+        """Convenience helper to parse a ``requests.Response`` object."""
+        soup = BeautifulSoup(response.content, "lxml")
+        return self.parse_url_data(soup, url)
+
+    def finalize_parsing(self) -> None:
+        """Emit a summary after parsing many pages."""
+        if hasattr(self.links_parser, "log_final_summary"):
+            self.links_parser.log_final_summary()
+        if hasattr(self.links_parser, "log_cache_summary"):
+            self.links_parser.log_cache_summary()
+

--- a/tests/test_links_parser_integration.py
+++ b/tests/test_links_parser_integration.py
@@ -1,5 +1,7 @@
 import datetime
-import requests
+import pytest
+
+requests = pytest.importorskip("requests")
 
 from seofrog.core.crawler import SEOFrog, URLManager
 from seofrog.core.config import CrawlConfig

--- a/tests/test_seo_parser_basic.py
+++ b/tests/test_seo_parser_basic.py
@@ -1,0 +1,19 @@
+import pytest
+
+bs4 = pytest.importorskip("bs4")
+BeautifulSoup = bs4.BeautifulSoup
+
+from seofrog.parsers.seo_parser import SEOParser
+
+
+def test_seo_parser_basic_parse():
+    html = "<html><head><title>Title</title></head><body><a href='/next'>Next</a></body></html>"
+    soup = BeautifulSoup(html, "lxml")
+    parser = SEOParser()
+    result = parser.parse_url_data(soup, "http://example.com")
+
+    assert result["url"] == "http://example.com"
+    # LinksParser should have added link details without crashing
+    assert "internal_links_details" in result
+    assert isinstance(result["internal_redirects_details"], list)
+


### PR DESCRIPTION
## Summary
- create working `SEOParser` that aggregates modular parsers
- ensure redirect info from `LinksParser` is exposed via `internal_redirects_details`
- add tests for `SEOParser`
- skip tests if dependencies like requests or bs4 are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869bdda6c04832aafbf6cfd02eab4c7